### PR TITLE
chore: add Vite preprocessorOptions

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,5 +11,13 @@ export default defineConfig(() => {
         'Cache-Control': 'public, max-age=600',
       },
     },
+    css: {
+      preprocessorOptions: {
+        scss: {
+          additionalData: (source, id) =>
+            id.endsWith('main.scss') ? source : '',
+        },
+      },
+    },
   };
 });


### PR DESCRIPTION
This PR will solve `npm run dev` errors because with `npm run build` and `npm run preview` is working fine.

example

```
[sass] Undefined mixin.
  ╷
3 │ ┌   @include responsive(desktop)
4 │ │   {
5 │ │     font-size: 75%;
6 │ └   }
  ╵
  src\global\style\base\_base.scss 3:3  root stylesheet
```

I added a Vite preprocessorOptions

```
css: {
  preprocessorOptions: {
    scss: {
      additionalData: (source, id) => id.endsWith('main.scss') ? source : '',
    },
  },
},
```

Close [#4144](https://github.com/BuilderIO/qwik/issues/4144)
